### PR TITLE
Fix for Issue: #10

### DIFF
--- a/er_viewmode.info
+++ b/er_viewmode.info
@@ -4,3 +4,4 @@ package = Fields
 core = 7.x
 
 dependencies[] = entityreference
+files[] = plugins/behavior/ERViewModeBehavior.class.php


### PR DESCRIPTION
### Changes
- Load the Class file explicitly so that ctools loads this when using with Features 
### Technical Details
- Loaded the `ERViewModeBehavior` class from the `.info` file using the files[]
#### Key Affected Code
- er_viewmode.info
### References
- https://www.drupal.org/node/1962284
- https://github.com/adaptdk/er_viewmode/issues/10
